### PR TITLE
Add SCT deployment profiles and filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Custom Maker Toolkit
+
+This repository contains three standalone HTML tools:
+
+- **index.html** – Landing page for the toolkit.
+- **maker.html** – Configuration maker used to author SCT deployment modality guidance and export `config.json` files.
+- **template.html** – Assessment template that loads exported configurations for review.
+
+## Capturing SCT deployment profiles
+
+`maker.html` now lets you create **SCT Deployment Profiles**. Use the card below the modality guidance grid to:
+
+- Document which deployment modalities (Embedded, Coupled, Self-sustained) a specific SCT can support.
+- Summarize the team’s clinical focus and highlight checklist priorities such as operational support, staffing, WASH/IPCs, and clinical capabilities using the provided readiness fields.
+- Record what the SCT will always provide and what the host facility must guarantee before deployment, along with coordination and contingency notes.
+
+When you export `config.json`, these profiles are saved alongside the modality metadata. Upload the same file in `template.html` to:
+
+- Filter checklist standards by SCT profile and/or individual deployment modality.
+- Review a dedicated **SCT Profiles** tab summarizing responsibilities and readiness considerations drawn from the Comprehensive Facility Readiness Checklist.
+
+## Accessing the tools locally
+
+1. Clone or download this repository to your computer.
+2. Open the project folder in your file explorer.
+3. Double-click any of the HTML files (for example, `maker.html`) to open it directly in your web browser.
+4. If your browser blocks local file access, right-click the file and choose **Open with** followed by your preferred browser.
+
+## Working with exported files
+
+- When you press **Save Configuration** in `maker.html`, your browser downloads a `config.json` file. You can find it in your browser's default downloads folder unless you choose a different location.
+- To load a previously saved configuration, click **Import Configuration** in `maker.html` and select the `config.json` file from your computer.
+- The same `config.json` file can be uploaded in `template.html` to review the assessment checklist filtered by deployment modality.
+
+## Viewing changes on a local web server (optional)
+
+Some browsers restrict features like file downloads when running straight from the file system. To avoid this, you can serve the files through a lightweight HTTP server:
+
+```bash
+# From the repository root
+python3 -m http.server 8000
+```
+
+Then visit <http://localhost:8000/maker.html> (or the relevant file) in your browser.

--- a/maker.html
+++ b/maker.html
@@ -363,7 +363,7 @@
     const MODALITY_OPTIONS = [
         { key: 'embedded', label: 'Embedded', icon: 'fa-hospital-user', badgeClass: 'bg-primary' },
         { key: 'coupled', label: 'Coupled', icon: 'fa-link', badgeClass: 'bg-warning text-dark' },
-        { key: 'self-sustained', label: 'Self-sustained', icon: 'fa-campground', badgeClass: 'bg-success' }
+        { key: 'self-sustained', label: 'Self-Sustained', icon: 'fa-campground', badgeClass: 'bg-success' }
     ];
 
     const DEFAULT_MODALITIES = {
@@ -386,7 +386,7 @@
             hostFacilitySupport: 'List site services and operational enablers that must remain accessible from the host while coupled.'
         },
         'self-sustained': {
-            label: 'Self-sustained',
+            label: 'Self-Sustained',
             description: 'The SCT operates from fully self-sufficient facilities separate from any host infrastructure.',
             operationalSupport: 'The SCT manages all site services including power generation, accommodation, logistics, waste, security and resupply throughout deployment duration.',
             washConsiderations: 'Deploy self-contained water, sanitation and waste systems with surge capacity and stringent IPC controls for high-risk procedures.',
@@ -419,22 +419,22 @@
     const WASH_DESCRIPTORS = {
         'embedded': {
             single: 'Per the Comprehensive Facility Readiness Checklist, the host facility provides core WASH services while the SCT verifies IPC gaps and supports mitigation measures.',
-            short: 'Host provides core WASH services'
+            short: 'Host provides'
         },
         'coupled': {
             single: 'The Comprehensive Facility Readiness Checklist highlights the need to formalize shared WASH responsibilities with the host, including back-up purification and waste pathways.',
-            short: 'Shared WASH systems with documented backups'
+            short: 'Shared with host; document backups'
         },
         'self-sustained': {
             single: 'The SCT deploys a fully self-sustained WASH package with its own purification, sanitation and waste management capabilities per the readiness checklist.',
-            short: 'SCT provides the full WASH package'
+            short: 'SCT provides'
         }
     };
 
     const LOGISTICS_DESCRIPTORS = {
         'embedded': {
             single: 'Host facilities cover infrastructure, utilities and baseline logistics; SCT agreements should capture expectations and mitigation strategies from the readiness checklist.',
-            short: 'Host covers baseline logistics'
+            short: 'Host provides baseline support'
         },
         'coupled': {
             single: 'Coordinate with the host for primary provision of logistics while maintaining SCT back-up capabilities as outlined in the readiness checklist.',
@@ -442,7 +442,7 @@
         },
         'self-sustained': {
             single: 'The SCT operates an autonomous logistics package—power, accommodation, storage and resupply—aligned with the readiness checklist expectations.',
-            short: 'SCT deploys autonomous logistics'
+            short: 'SCT provides autonomously'
         }
     };
 

--- a/maker.html
+++ b/maker.html
@@ -33,9 +33,14 @@
         .btn-gradient { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border: none; color: white; }
         .btn-gradient:hover { background: linear-gradient(135deg, #764ba2 0%, #667eea 100%); color: white; }
         .action-bar { position: sticky; top: 0; background: white; padding: 20px 0; margin-bottom: 20px; border-bottom: 2px solid #e9ecef; z-index: 100; }
+        .action-helper { font-size: 0.9rem; color: #495057; margin-top: 10px; }
+        .save-feedback { display: none; margin-top: 10px; font-size: 0.95rem; border-radius: 8px; padding: 12px 16px; }
+        .save-feedback.show { display: block; }
         .drag-handle { cursor: move; color: #6c757d; margin-right: 10px; }
         .subsection-title-input { border: none; background: transparent; font-weight: bold; font-size: 1rem; padding: 5px; border-bottom: 1px dashed #ccc; }
         .subsection-title-input:focus { outline: none; border-bottom: 2px solid #667eea; background: white; }
+        .modality-guidance { font-size: 0.85rem; color: #495057; background: #f8f9fa; border: 1px solid #e9ecef; border-radius: 10px; padding: 10px 14px; margin-top: 12px; display: flex; align-items: center; gap: 10px; }
+        .modality-guidance .badge { font-size: 0.75rem; }
     </style>
 </head>
 <body>
@@ -43,6 +48,41 @@
         <div class="maker-header">
             <h1><i class="fas fa-tools"></i> Enhanced Config Maker</h1>
             <p class="text-muted lead">Create and customize your assessment tool configuration with advanced editing features</p>
+        </div>
+
+        <div class="card my-4 border-0 shadow">
+            <div class="card-header bg-gradient text-white" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);">
+                <h5 class="mb-0"><i class="fas fa-sitemap me-2"></i>Deployment Modalities Guidance</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted mb-4">
+                    Capture how each Specialized Care Team (SCT) modality should operate, including operational support,
+                    WASH and clinical considerations. This information will be embedded in the generated checklist and can
+                    be linked to specific standards for clearer responsibility sharing with host facilities.
+                </p>
+                <div class="row g-4" id="modalities-grid"></div>
+            </div>
+        </div>
+
+        <div class="card my-4 border-0 shadow">
+            <div class="card-header bg-gradient text-white d-flex justify-content-between align-items-center flex-wrap gap-2"
+                 style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);">
+                <h5 class="mb-0"><i class="fas fa-people-group me-2"></i>SCT Deployment Profiles</h5>
+                <button class="btn btn-light btn-sm" id="btn-add-profile">
+                    <i class="fas fa-plus me-2"></i>Add SCT Profile
+                </button>
+            </div>
+            <div class="card-body">
+                <p class="text-muted mb-4">
+                    Document how individual SCTs approach different deployment modalities. Profiles capture the mix of
+                    modalities a team can operate under, highlight checklist priorities (operational support, staffing,
+                    logistics, WASH/IPCs, clinical capabilities) and clarify what the SCT provides versus what the host
+                    facility must guarantee ahead of deployment.
+                </p>
+                <div class="alert alert-info" id="profiles-empty">No SCT profiles configured yet. Use “Add SCT Profile” to
+                    start mapping readiness expectations per team.</div>
+                <div class="row g-4" id="profiles-container"></div>
+            </div>
         </div>
 
         <div class="action-bar">
@@ -57,6 +97,8 @@
                     <i class="fas fa-save me-2"></i>Save Configuration
                 </button>
             </div>
+            <p class="action-helper text-center mb-0">Descarga un archivo <code>config.json</code> en tu carpeta de descargas. Usa “Import Config” para volver a cargarlo cuando lo necesites.</p>
+            <div id="save-feedback" class="save-feedback bg-light border border-success text-success text-center" role="status" aria-live="polite"></div>
         </div>
 
         <div class="card my-4 border-0 shadow">
@@ -308,6 +350,682 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
     const ICONS = ['fa-info-circle', 'fa-book', 'fa-building', 'fa-star', 'fa-cogs', 'fa-stethoscope', 'fa-truck', 'fa-hand-holding-water', 'fa-file-alt', 'fa-heart', 'fa-user-md', 'fa-clipboard-check', 'fa-shield-alt', 'fa-ambulance', 'fa-hospital', 'fa-medkit', 'fa-pills', 'fa-syringe', 'fa-microscope', 'fa-flask', 'fa-heartbeat', 'fa-first-aid', 'fa-briefcase-medical'];
+
+    const escapeHtml = (unsafe = '') => unsafe
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+
+    const formatMultiline = (text = '') => escapeHtml(text).replace(/\n/g, '<br>');
+
+    const MODALITY_OPTIONS = [
+        { key: 'embedded', label: 'Embedded', icon: 'fa-hospital-user', badgeClass: 'bg-primary' },
+        { key: 'coupled', label: 'Coupled', icon: 'fa-link', badgeClass: 'bg-warning text-dark' },
+        { key: 'self-sustained', label: 'Self-sustained', icon: 'fa-campground', badgeClass: 'bg-success' }
+    ];
+
+    const DEFAULT_MODALITIES = {
+        'embedded': {
+            label: 'Embedded',
+            description: 'The SCT integrates into an existing facility and aligns with host governance and patient pathways.',
+            operationalSupport: 'Host facility covers infrastructure, utilities, waste management and non-specialized logistics while the SCT provides specialty equipment, drugs and consumables.',
+            washConsiderations: 'Use host WASH and IPC systems, confirming isolation capacity, decontamination workflows and water quality before activating services.',
+            clinicalConsiderations: 'Synchronize specialized protocols, documentation and referral triggers with host teams to avoid duplicating processes.',
+            teamResponsibilities: 'Clarify which specialist staff, devices and pharmaceuticals the SCT will always provide when embedded.',
+            hostFacilitySupport: 'Document which infrastructure, utilities and ancillary services the host must guarantee before arrival.'
+        },
+        'coupled': {
+            label: 'Coupled',
+            description: 'The SCT deploys additional infrastructure on the host site and shares select support services.',
+            operationalSupport: 'Define which support services remain with the host and which are provided by the SCT (power, logistics, security, waste). Establish joint supply and maintenance routines.',
+            washConsiderations: 'Plan for shared water and sanitation usage, scaling storage, treatment and waste streams for the combined footprint, and align hygiene promotion messages.',
+            clinicalConsiderations: 'Clarify triage interfaces, patient flow, data sharing and referral pathways between the temporary SCT structures and the host facility.',
+            teamResponsibilities: 'Describe mobile assets, staffing and clinical functions that the SCT brings to bridge gaps on the shared site.',
+            hostFacilitySupport: 'List site services and operational enablers that must remain accessible from the host while coupled.'
+        },
+        'self-sustained': {
+            label: 'Self-sustained',
+            description: 'The SCT operates from fully self-sufficient facilities separate from any host infrastructure.',
+            operationalSupport: 'The SCT manages all site services including power generation, accommodation, logistics, waste, security and resupply throughout deployment duration.',
+            washConsiderations: 'Deploy self-contained water, sanitation and waste systems with surge capacity and stringent IPC controls for high-risk procedures.',
+            clinicalConsiderations: 'Ensure comprehensive clinical capability (stabilization, referral coordination, pharmacy, diagnostics) and continuity planning without host facility support.',
+            teamResponsibilities: 'Outline the full operational and clinical package the SCT delivers independently, including contingencies.',
+            hostFacilitySupport: 'Specify only the critical coordination touchpoints still required from national or local systems.'
+        }
+    };
+
+    const DEFAULT_MODALITY_KEYS = MODALITY_OPTIONS.map(option => option.key);
+
+    const PROFILE_FIELD_GROUPS = [
+        { key: 'operationalSupport', label: 'Operational Support & Logistics' },
+        { key: 'staffing', label: 'Staffing & Integration' },
+        { key: 'spacesInfrastructure', label: 'Spaces & Structures' },
+        { key: 'suppliesEquipment', label: 'Supplies & Equipment' },
+        { key: 'coordinationCommunication', label: 'Coordination & Communication' },
+        { key: 'safetySecurity', label: 'Safety & Security' },
+        { key: 'clinicalServices', label: 'Medical Services & Capabilities' },
+        { key: 'washIpc', label: 'WASH / IPC' },
+        { key: 'integrationNotes', label: 'Host Facility Agreements & Notes' }
+    ];
+
+    const SECTION_MODALITY_CATEGORY = {
+        'wash-standards': 'wash',
+        'logistic-standards': 'logistics',
+        'clinical-standards': 'clinical'
+    };
+
+    const WASH_DESCRIPTORS = {
+        'embedded': {
+            single: 'Per the Comprehensive Facility Readiness Checklist, the host facility provides core WASH services while the SCT verifies IPC gaps and supports mitigation measures.',
+            short: 'Host provides core WASH services'
+        },
+        'coupled': {
+            single: 'The Comprehensive Facility Readiness Checklist highlights the need to formalize shared WASH responsibilities with the host, including back-up purification and waste pathways.',
+            short: 'Shared WASH systems with documented backups'
+        },
+        'self-sustained': {
+            single: 'The SCT deploys a fully self-sustained WASH package with its own purification, sanitation and waste management capabilities per the readiness checklist.',
+            short: 'SCT provides the full WASH package'
+        }
+    };
+
+    const LOGISTICS_DESCRIPTORS = {
+        'embedded': {
+            single: 'Host facilities cover infrastructure, utilities and baseline logistics; SCT agreements should capture expectations and mitigation strategies from the readiness checklist.',
+            short: 'Host covers baseline logistics'
+        },
+        'coupled': {
+            single: 'Coordinate with the host for primary provision of logistics while maintaining SCT back-up capabilities as outlined in the readiness checklist.',
+            short: 'Coordinate with host for primary provision but maintain backup capabilities'
+        },
+        'self-sustained': {
+            single: 'The SCT operates an autonomous logistics package—power, accommodation, storage and resupply—aligned with the readiness checklist expectations.',
+            short: 'SCT deploys autonomous logistics'
+        }
+    };
+
+    function getModalityLabel(modalityKey) {
+        return MODALITY_OPTIONS.find(opt => opt.key === modalityKey)?.label || modalityKey;
+    }
+
+    function combineSummaries(modalities, descriptorMap) {
+        return modalities
+            .map(mode => {
+                const descriptor = descriptorMap[mode];
+                if (!descriptor) return '';
+                return `${getModalityLabel(mode)}: ${descriptor.short}`;
+            })
+            .filter(Boolean)
+            .join(' | ');
+    }
+
+    function buildGuidance(category, modalities = []) {
+        const uniqueModalities = Array.from(new Set((Array.isArray(modalities) ? modalities : []).filter(Boolean)));
+        uniqueModalities.sort((a, b) => {
+            const orderA = DEFAULT_MODALITY_KEYS.indexOf(a);
+            const orderB = DEFAULT_MODALITY_KEYS.indexOf(b);
+            return (orderA === -1 ? Number.MAX_SAFE_INTEGER : orderA) - (orderB === -1 ? Number.MAX_SAFE_INTEGER : orderB);
+        });
+        if (!uniqueModalities.length) {
+            return {
+                badge: 'Modalities Pending',
+                badgeClass: 'bg-secondary',
+                context: 'Selecciona modalidades para conectar responsabilidades del SCT y del establecimiento anfitrión según el Checklist Integral de Preparación de Instalaciones.'
+            };
+        }
+
+        if (category === 'wash') {
+            if (uniqueModalities.length === 1) {
+                const mode = uniqueModalities[0];
+                const descriptor = WASH_DESCRIPTORS[mode];
+                return {
+                    badge: mode === 'embedded' ? 'Host Supported' : mode === 'coupled' ? 'Shared Systems' : 'SCT Self-Sufficient',
+                    badgeClass: mode === 'embedded' ? 'bg-primary' : mode === 'coupled' ? 'bg-warning text-dark' : 'bg-success',
+                    context: descriptor?.single || 'Aplica el Checklist Integral de Preparación de Instalaciones para detallar la responsabilidad WASH.'
+                };
+            }
+            return {
+                badge: 'Mode-Dependent',
+                badgeClass: 'bg-info text-dark',
+                context: combineSummaries(uniqueModalities, WASH_DESCRIPTORS)
+            };
+        }
+
+        if (category === 'logistics') {
+            if (uniqueModalities.length === 1) {
+                const mode = uniqueModalities[0];
+                const descriptor = LOGISTICS_DESCRIPTORS[mode];
+                if (mode === 'coupled') {
+                    return {
+                        badge: 'Coordination Required',
+                        badgeClass: 'bg-warning text-dark',
+                        context: descriptor?.single || 'Coordinate with host for primary provision but maintain backup capabilities.'
+                    };
+                }
+                if (mode === 'self-sustained') {
+                    return {
+                        badge: 'Autonomous Logistics',
+                        badgeClass: 'bg-success',
+                        context: descriptor?.single || 'La logística recae íntegramente en el SCT.'
+                    };
+                }
+                return {
+                    badge: 'Host Supported',
+                    badgeClass: 'bg-primary',
+                    context: descriptor?.single || 'El establecimiento anfitrión lidera la logística base.'
+                };
+            }
+
+            const includesCoupled = uniqueModalities.includes('coupled');
+            const includesEmbedded = uniqueModalities.includes('embedded');
+            const includesSelf = uniqueModalities.includes('self-sustained');
+
+            let badge = 'Hybrid Support Plan';
+            if (includesCoupled && includesEmbedded && !includesSelf) badge = 'Shared Logistics Plan';
+            else if (includesCoupled && includesSelf && !includesEmbedded) badge = 'Layered Logistics';
+            else if (includesEmbedded && includesSelf && !includesCoupled) badge = 'Mode-Dependent';
+            else if (includesCoupled && includesEmbedded && includesSelf) badge = 'Mode-Dependent';
+
+            return {
+                badge,
+                badgeClass: 'bg-info text-dark',
+                context: combineSummaries(uniqueModalities, LOGISTICS_DESCRIPTORS)
+            };
+        }
+
+        if (category === 'clinical') {
+            return {
+                badge: 'SCT Responsibility',
+                badgeClass: 'bg-success',
+                context: 'This standard is always the responsibility of the SCT.'
+            };
+        }
+
+        return {
+            badge: 'Contextual Planning',
+            badgeClass: 'bg-secondary',
+            context: 'Utiliza el Checklist Integral de Preparación de Instalaciones para aclarar responsabilidades compartidas.'
+        };
+    }
+
+    function updateDeploymentModeUI(targetElement = null) {
+        const elements = targetElement ? [targetElement] : Array.from(document.querySelectorAll('.modality-guidance'));
+        elements.forEach(element => {
+            if (!element) return;
+            const sectionKey = element.dataset.section;
+            const scope = element.dataset.scope;
+            let modalities = [];
+
+            if (scope === 'section') {
+                modalities = TOOL_CONFIG[sectionKey]?.modalities || [];
+            } else {
+                const parentItem = element.closest('.subsection-item');
+                const container = parentItem?.parentElement;
+                let itemIndex = -1;
+                if (container && parentItem) {
+                    itemIndex = Array.from(container.children).indexOf(parentItem);
+                }
+                if (itemIndex >= 0) {
+                    modalities = TOOL_CONFIG[sectionKey]?.subsections?.[itemIndex]?.modalities || [];
+                }
+            }
+
+            const guidance = buildGuidance(SECTION_MODALITY_CATEGORY[sectionKey], modalities);
+            element.innerHTML = `<span class="badge ${guidance.badgeClass}">${guidance.badge}</span><span>${guidance.context}</span>`;
+        });
+    }
+
+    const deepClone = (value) => JSON.parse(JSON.stringify(value));
+
+    const normalizeDeploymentModalities = (modalities = {}) => {
+        const normalized = {};
+        const keys = new Set([
+            ...Object.keys(DEFAULT_MODALITIES),
+            ...Object.keys(modalities || {})
+        ]);
+
+        keys.forEach(key => {
+            normalized[key] = {
+                label: DEFAULT_MODALITIES[key]?.label || modalities[key]?.label || key,
+                description: '',
+                operationalSupport: '',
+                washConsiderations: '',
+                clinicalConsiderations: '',
+                teamResponsibilities: '',
+                hostFacilitySupport: '',
+                ...(DEFAULT_MODALITIES[key] || {}),
+                ...(modalities[key] || {})
+            };
+        });
+
+        return normalized;
+    };
+
+    let DEPLOYMENT_MODALITIES = normalizeDeploymentModalities();
+    const createEmptyProfile = () => {
+        const readiness = {};
+        PROFILE_FIELD_GROUPS.forEach(field => {
+            readiness[field.key] = '';
+        });
+        return {
+            id: `profile-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+            name: '',
+            summary: '',
+            modalities: [...DEFAULT_MODALITY_KEYS],
+            readiness,
+            sctDeliverables: '',
+            hostExpectations: '',
+            coordinationNotes: ''
+        };
+    };
+
+    const normalizeProfile = (profile = {}) => {
+        const base = createEmptyProfile();
+        return {
+            ...base,
+            ...profile,
+            id: profile.id || base.id,
+            summary: profile.summary || '',
+            modalities: Array.isArray(profile.modalities) && profile.modalities.length
+                ? [...new Set(profile.modalities)]
+                : [...DEFAULT_MODALITY_KEYS],
+            readiness: {
+                ...base.readiness,
+                ...(profile.readiness || {})
+            },
+            sctDeliverables: profile.sctDeliverables || '',
+            hostExpectations: profile.hostExpectations || '',
+            coordinationNotes: profile.coordinationNotes || ''
+        };
+    };
+
+    let SCT_PROFILES = [normalizeProfile({
+        name: 'Perfil base SCT HID',
+        summary: 'Referencia inicial para SCTs que pueden operar como Embedded, Coupled o Self-sustained. Ajusta según la especialidad clínica y el contexto operativo.',
+        readiness: {
+            operationalSupport: 'Embedded: validar suministro de servicios básicos del anfitrión. Coupled: acordar responsabilidades compartidas (energía, residuos, movilidad). Self-sustained: planificar generación y soporte autónomo.',
+            staffing: 'Alinear roles y procesos de inducción con el anfitrión para modalidades Embedded/Coupled. Mantener rotaciones completas y capacidades críticas propias para Self-sustained.',
+            spacesInfrastructure: 'Embedded: confirmar que los espacios cumplen requisitos clínicos y de bioseguridad. Coupled: preparar estructuras modulares compatibles con el sitio. Self-sustained: desplegar infraestructura autónoma adaptable.',
+            suppliesEquipment: 'Mantener cadena de suministros propia en todas las modalidades. Integrar reposición con el anfitrión cuando sea viable (Embedded/Coupled) y planificar stock ampliado para Self-sustained.',
+            coordinationCommunication: 'Establecer canales de coordinación diaria con el anfitrión y mecanismos de reporte al EMTCC. Garantizar redundancia de comunicaciones para entornos Self-sustained.',
+            safetySecurity: 'Codiseñar planes de seguridad y evacuación con el anfitrión. Para despliegues autónomos, incluir perímetro propio y protocolos de respuesta rápida.',
+            clinicalServices: 'Definir alcance clínico, rutas de referencia y criterios de admisión por modalidad. Incorporar planes de contingencia para diagnósticos, farmacia e imagenología.',
+            washIpc: 'Aplicar el Checklist integral para acordar responsabilidades WASH. Proveer capacidades autónomas de tratamiento y residuos cuando sea necesario.',
+            integrationNotes: 'Utilizar la lista de verificación de integración EMT-SCT para documentar acuerdos previos, riesgos y mitigaciones.'
+        },
+        sctDeliverables: 'Equipo clínico especializado completo, suministros críticos, SOPs para transición de turnos, infraestructura modular y capacidades de laboratorio/diagnóstico requeridas.',
+        hostExpectations: 'Clarificar disponibilidad de servicios esenciales (energía, agua, oxígeno), acceso a rutas de referencia, seguridad en sitio y coordinación administrativa antes de desplegar.',
+        coordinationNotes: 'Aplicar revisiones periódicas con el anfitrión y el EMTCC para ajustar soportes compartidos y gestionar contingencias de suministros o personal.'
+    })];
+    let hasDocumentInputListener = false;
+    let hasModalityChangeListener = false;
+
+    const ensureModalitiesStructure = (config) => {
+        Object.values(config).forEach(section => {
+            if (!Array.isArray(section.modalities)) {
+                section.modalities = [...DEFAULT_MODALITY_KEYS];
+            }
+            if (section.hasSubsections && Array.isArray(section.subsections)) {
+                section.subsections.forEach(sub => {
+                    if (!Array.isArray(sub.modalities)) {
+                        sub.modalities = [...DEFAULT_MODALITY_KEYS];
+                    }
+                });
+            }
+        });
+    };
+
+    function renderModalitiesUI() {
+        const container = document.getElementById('modalities-grid');
+        if (!container) return;
+
+        container.innerHTML = Object.entries(DEPLOYMENT_MODALITIES).map(([key, data]) => `
+            <div class="col-md-4">
+                <div class="p-4 border rounded-4 h-100 shadow-sm">
+                    <div class="d-flex align-items-center mb-3">
+                        <span class="badge ${MODALITY_OPTIONS.find(opt => opt.key === key)?.badgeClass || 'bg-secondary'} me-2">
+                            <i class="fas ${MODALITY_OPTIONS.find(opt => opt.key === key)?.icon || 'fa-sitemap'}"></i>
+                        </span>
+                        <div>
+                            <h5 class="mb-0">${data.label}</h5>
+                            <small class="text-muted text-uppercase">${key.replace('-', ' ')}</small>
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Definition</label>
+                        <textarea class="form-control modality-field" rows="3" data-modality="${key}" data-field="description" placeholder="How this modality is defined"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Operational & Logistics</label>
+                        <textarea class="form-control modality-field" rows="3" data-modality="${key}" data-field="operationalSupport" placeholder="Operational support responsibilities"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">WASH / IPC</label>
+                        <textarea class="form-control modality-field" rows="3" data-modality="${key}" data-field="washConsiderations" placeholder="Critical WASH & IPC considerations"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Clinical Focus</label>
+                        <textarea class="form-control modality-field" rows="3" data-modality="${key}" data-field="clinicalConsiderations" placeholder="Clinical management implications"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">What the SCT provides</label>
+                        <textarea class="form-control modality-field" rows="3" data-modality="${key}" data-field="teamResponsibilities" placeholder="Critical assets, personnel and services delivered by the SCT"></textarea>
+                    </div>
+                    <div>
+                        <label class="form-label fw-semibold">Support expected from host facilities</label>
+                        <textarea class="form-control modality-field" rows="3" data-modality="${key}" data-field="hostFacilitySupport" placeholder="Infrastructure, services or coordination that must be in place"></textarea>
+                    </div>
+                </div>
+            </div>
+        `).join('');
+
+        Object.entries(DEPLOYMENT_MODALITIES).forEach(([key, data]) => {
+            ['description', 'operationalSupport', 'washConsiderations', 'clinicalConsiderations', 'teamResponsibilities', 'hostFacilitySupport'].forEach(field => {
+                const textarea = container.querySelector(`.modality-field[data-modality="${key}"][data-field="${field}"]`);
+                if (textarea) textarea.value = data[field] || '';
+            });
+        });
+    }
+
+    function renderProfilesUI() {
+        const container = document.getElementById('profiles-container');
+        const emptyState = document.getElementById('profiles-empty');
+        if (!container) return;
+
+        if (!Array.isArray(SCT_PROFILES) || SCT_PROFILES.length === 0) {
+            container.innerHTML = '';
+            if (emptyState) emptyState.classList.remove('d-none');
+            return;
+        }
+
+        if (emptyState) emptyState.classList.add('d-none');
+
+        container.innerHTML = SCT_PROFILES.map(profile => {
+            const readinessFields = PROFILE_FIELD_GROUPS.map(group => `
+                <div class="col-md-6">
+                    <label class="form-label fw-semibold">${group.label}</label>
+                    <textarea class="form-control profile-readiness-field" rows="3" data-profile="${profile.id}" data-field="${group.key}" placeholder="Describe ${group.label.toLowerCase()}">${escapeHtml(profile.readiness?.[group.key] || '')}</textarea>
+                </div>
+            `).join('');
+
+            const modalityBadges = MODALITY_OPTIONS.map(option => `
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input profile-modality-toggle" type="checkbox" data-profile="${profile.id}" data-modality="${option.key}" ${profile.modalities?.includes(option.key) ? 'checked' : ''}>
+                    <label class="form-check-label small"><span class="badge ${option.badgeClass} me-1"><i class="fas ${option.icon}"></i></span>${option.label}</label>
+                </div>
+            `).join('');
+
+            return `
+                <div class="col-12">
+                    <div class="border rounded-4 p-4 shadow-sm">
+                        <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+                            <div class="flex-grow-1">
+                                <label class="form-label fw-semibold">Profile name</label>
+                                <input type="text" class="form-control profile-name-input" data-profile="${profile.id}" value="${escapeHtml(profile.name || '')}" placeholder="e.g. HID SCT - Critical Care">
+                            </div>
+                            <div class="text-end">
+                                <button class="btn btn-sm btn-outline-secondary me-2 profile-action" data-action="duplicate" data-profile="${profile.id}"><i class="fas fa-copy me-1"></i>Duplicate</button>
+                                <button class="btn btn-sm btn-outline-danger profile-action" data-action="remove" data-profile="${profile.id}"><i class="fas fa-trash me-1"></i>Remove</button>
+                            </div>
+                        </div>
+                        <div class="mt-3">
+                            <label class="form-label fw-semibold">Summary / clinical focus</label>
+                            <textarea class="form-control profile-summary-input" rows="2" data-profile="${profile.id}" placeholder="What services does this SCT provide and in which contexts?">${escapeHtml(profile.summary || '')}</textarea>
+                        </div>
+                        <div class="mt-3">
+                            <label class="form-label fw-semibold">Supported deployment modalities</label>
+                            <div class="d-flex flex-wrap gap-3">${modalityBadges}</div>
+                            <div class="form-text">Desmarca modalidades no disponibles para esta SCT.</div>
+                        </div>
+                        <div class="row g-3 mt-3">${readinessFields}</div>
+                        <div class="row g-3 mt-3">
+                            <div class="col-md-6">
+                                <label class="form-label fw-semibold">SCT delivers / brings</label>
+                                <textarea class="form-control profile-sct-field" rows="3" data-profile="${profile.id}" placeholder="Equipos, personal y servicios garantizados por la SCT">${escapeHtml(profile.sctDeliverables || '')}</textarea>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label fw-semibold">Host facility must ensure</label>
+                                <textarea class="form-control profile-host-field" rows="3" data-profile="${profile.id}" placeholder="Infraestructura, suministros o soporte que exige la SCT">${escapeHtml(profile.hostExpectations || '')}</textarea>
+                            </div>
+                        </div>
+                        <div class="mt-3">
+                            <label class="form-label fw-semibold">Coordination notes & contingencies</label>
+                            <textarea class="form-control profile-coordination-field" rows="2" data-profile="${profile.id}" placeholder="Protocolos de coordinación, escalamiento y mitigaciones">${escapeHtml(profile.coordinationNotes || '')}</textarea>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
+    function renderModalityCheckboxes(sectionKey, selectedModalities = DEFAULT_MODALITY_KEYS, scope = 'subsection', uniqueSuffix = '') {
+        const selected = Array.isArray(selectedModalities) && selectedModalities.length ? selectedModalities : DEFAULT_MODALITY_KEYS;
+        return `
+            <div class="mt-3">
+                <label class="form-label text-muted small text-uppercase fw-semibold">Applicable deployment modalities</label>
+                <div class="d-flex flex-wrap gap-3">
+                    ${MODALITY_OPTIONS.map(option => {
+                        const inputId = `modality-${sectionKey}-${scope}-${uniqueSuffix}-${option.key}`;
+                        const isChecked = selected.includes(option.key);
+                        return `
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input modality-checkbox" type="checkbox" value="${option.key}" data-section="${sectionKey}" data-scope="${scope}" id="${inputId}" ${isChecked ? 'checked' : ''}>
+                                <label class="form-check-label small" for="${inputId}"><i class="fas ${option.icon} me-1"></i>${option.label}</label>
+                            </div>`;
+                    }).join('')}
+                </div>
+                <div class="modality-guidance" data-section="${sectionKey}" data-scope="${scope}" data-index="${uniqueSuffix}"></div>
+            </div>
+        `;
+    }
+
+    function handleDocumentInput(e) {
+        if (e.target.classList.contains('subsection-title-input')) {
+            const section = e.target.dataset.section;
+            const index = e.target.dataset.index;
+            const titleElement = document.getElementById(`subsection-title-${section}-${index}`);
+            if (titleElement) {
+                titleElement.textContent = e.target.value;
+            }
+            if (TOOL_CONFIG[section] && TOOL_CONFIG[section].subsections[index]) {
+                TOOL_CONFIG[section].subsections[index].title = e.target.value;
+            }
+        }
+
+        if (e.target.classList.contains('modality-field')) {
+            const modalityKey = e.target.dataset.modality;
+            const field = e.target.dataset.field;
+            if (DEPLOYMENT_MODALITIES[modalityKey]) {
+                DEPLOYMENT_MODALITIES[modalityKey][field] = e.target.value;
+            }
+        }
+
+        if (e.target.dataset.profile) {
+            const profileId = e.target.dataset.profile;
+            const profile = SCT_PROFILES.find(p => p.id === profileId);
+            if (!profile) return;
+
+            if (e.target.classList.contains('profile-name-input')) {
+                profile.name = e.target.value;
+            } else if (e.target.classList.contains('profile-summary-input')) {
+                profile.summary = e.target.value;
+            } else if (e.target.classList.contains('profile-readiness-field')) {
+                const fieldKey = e.target.dataset.field;
+                if (!profile.readiness) profile.readiness = {};
+                profile.readiness[fieldKey] = e.target.value;
+            } else if (e.target.classList.contains('profile-sct-field')) {
+                profile.sctDeliverables = e.target.value;
+            } else if (e.target.classList.contains('profile-host-field')) {
+                profile.hostExpectations = e.target.value;
+            } else if (e.target.classList.contains('profile-coordination-field')) {
+                profile.coordinationNotes = e.target.value;
+            }
+        }
+    }
+
+    function handleModalityCheckboxChange(e) {
+        if (e.target.classList.contains('profile-modality-toggle')) {
+            const profileId = e.target.dataset.profile;
+            const modality = e.target.dataset.modality;
+            const profile = SCT_PROFILES.find(p => p.id === profileId);
+            if (!profile || !modality) return;
+            if (!Array.isArray(profile.modalities)) profile.modalities = [];
+            if (e.target.checked) {
+                if (!profile.modalities.includes(modality)) profile.modalities.push(modality);
+            } else {
+                profile.modalities = profile.modalities.filter(m => m !== modality);
+            }
+            return;
+        }
+
+        if (!e.target.classList.contains('modality-checkbox')) return;
+
+        const section = e.target.dataset.section;
+        const modality = e.target.value;
+        if (!section || !modality) return;
+
+        const parentSubsection = e.target.closest('.subsection-item');
+        if (parentSubsection) {
+            const container = parentSubsection.parentElement;
+            const itemIndex = Array.from(container.children).indexOf(parentSubsection);
+            const subsection = TOOL_CONFIG[section]?.subsections?.[itemIndex];
+            if (!subsection) return;
+            if (!Array.isArray(subsection.modalities)) subsection.modalities = [];
+            if (e.target.checked) {
+                if (!subsection.modalities.includes(modality)) subsection.modalities.push(modality);
+            } else {
+                subsection.modalities = subsection.modalities.filter(m => m !== modality);
+            }
+            const guidanceElement = parentSubsection.querySelector('.modality-guidance');
+            if (guidanceElement) updateDeploymentModeUI(guidanceElement);
+        } else {
+            const configSection = TOOL_CONFIG[section];
+            if (!configSection) return;
+            if (!Array.isArray(configSection.modalities)) configSection.modalities = [];
+            if (e.target.checked) {
+                if (!configSection.modalities.includes(modality)) configSection.modalities.push(modality);
+            } else {
+                configSection.modalities = configSection.modalities.filter(m => m !== modality);
+            }
+            const sectionGuidance = document.querySelector(`.modality-guidance[data-section="${section}"][data-scope="section"]`);
+            if (sectionGuidance) updateDeploymentModeUI(sectionGuidance);
+        }
+    }
+
+    function handleProfileAction(e) {
+        const action = e.currentTarget.dataset.action;
+        const profileId = e.currentTarget.dataset.profile;
+        if (!action || !profileId) return;
+        const index = SCT_PROFILES.findIndex(profile => profile.id === profileId);
+        if (index === -1) return;
+
+        if (action === 'remove') {
+            SCT_PROFILES.splice(index, 1);
+        } else if (action === 'duplicate') {
+            const source = SCT_PROFILES[index];
+            const clone = normalizeProfile({
+                ...deepClone(source),
+                id: null,
+                name: `${source.name || 'SCT Profile'} (copy)`
+            });
+            SCT_PROFILES.splice(index + 1, 0, clone);
+        }
+
+        renderProfilesUI();
+        addEventListeners();
+    }
+
+    function addNewProfile() {
+        SCT_PROFILES.push(createEmptyProfile());
+        renderProfilesUI();
+        addEventListeners();
+    }
+
+    function getModalityBadgeHtml(modalities = []) {
+        if (!Array.isArray(modalities) || modalities.length === 0) return '';
+        return `
+            <div class="mt-2 d-flex flex-wrap gap-2">
+                ${modalities.map(modality => {
+                    const option = MODALITY_OPTIONS.find(opt => opt.key === modality);
+                    if (!option) return '';
+                    return `<span class="badge ${option.badgeClass}"><i class="fas ${option.icon} me-1"></i>${option.label}</span>`;
+                }).join('')}
+            </div>
+        `;
+    }
+
+    function renderModalitiesPreview() {
+        if (!DEPLOYMENT_MODALITIES) return '';
+        return `
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-sitemap me-2"></i>Deployment Modalities Overview</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-4">
+                        ${Object.entries(DEPLOYMENT_MODALITIES).map(([key, data]) => {
+                            const option = MODALITY_OPTIONS.find(opt => opt.key === key) || {};
+                            return `
+                                <div class="col-md-4">
+                                    <div class="h-100 border rounded p-3">
+                                        <h6 class="fw-semibold"><i class="fas ${option.icon || 'fa-circle'} me-2"></i>${data.label}</h6>
+                                        <p class="text-muted small mb-2">${data.description || ''}</p>
+                                        <ul class="small ps-3 mb-0">
+                                            <li><strong>Operational / Logistics:</strong> ${data.operationalSupport || ''}</li>
+                                            <li><strong>WASH & IPC:</strong> ${data.washConsiderations || ''}</li>
+                                            <li><strong>Clinical focus:</strong> ${data.clinicalConsiderations || ''}</li>
+                                            <li><strong>SCT provides:</strong> ${data.teamResponsibilities || ''}</li>
+                                            <li><strong>Host support required:</strong> ${data.hostFacilitySupport || ''}</li>
+                                        </ul>
+                                    </div>
+                                </div>`;
+                        }).join('')}
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    function renderProfilesPreview() {
+        if (!Array.isArray(SCT_PROFILES) || SCT_PROFILES.length === 0) return '';
+
+        const profilesHtml = SCT_PROFILES.map(profile => {
+            const modalities = getModalityBadgeHtml(profile.modalities);
+            const readinessList = PROFILE_FIELD_GROUPS
+                .filter(group => (profile.readiness?.[group.key] || '').trim().length)
+                .map(group => `<li><strong>${group.label}:</strong> ${formatMultiline(profile.readiness?.[group.key] || '')}</li>`)
+                .join('');
+
+            return `
+                <div class="col-md-6">
+                    <div class="h-100 border rounded p-3">
+                        <h6 class="fw-semibold"><i class="fas fa-user-md me-2"></i>${escapeHtml(profile.name || 'Unnamed Profile')}</h6>
+                        ${profile.summary ? `<p class="text-muted small mb-2">${formatMultiline(profile.summary)}</p>` : ''}
+                        ${modalities}
+                        ${readinessList ? `<ul class="small ps-3 mt-3 mb-3">${readinessList}</ul>` : ''}
+                        <div class="small">
+                            <p class="mb-1"><strong>SCT delivers:</strong> ${formatMultiline(profile.sctDeliverables || 'Sin definir')}</p>
+                            <p class="mb-1"><strong>Host ensures:</strong> ${formatMultiline(profile.hostExpectations || 'Sin definir')}</p>
+                            ${profile.coordinationNotes ? `<p class="mb-0"><strong>Coordinación:</strong> ${formatMultiline(profile.coordinationNotes)}</p>` : ''}
+                        </div>
+                    </div>
+                </div>
+            `;
+        }).join('');
+
+        return `
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-people-group me-2"></i>SCT Deployment Profiles</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-4">${profilesHtml}</div>
+                </div>
+            </div>
+        `;
+    }
 
     let TOOL_CONFIG = {
         'info': { 
@@ -613,6 +1331,11 @@
     }
 
     function renderMakerUI() {
+        DEPLOYMENT_MODALITIES = normalizeDeploymentModalities(DEPLOYMENT_MODALITIES);
+        ensureModalitiesStructure(TOOL_CONFIG);
+        SCT_PROFILES = Array.isArray(SCT_PROFILES) ? SCT_PROFILES.map(normalizeProfile) : [];
+        renderModalitiesUI();
+        renderProfilesUI();
         const sectionsContainer = document.getElementById('sections-accordion');
         const weightsContainer = document.getElementById('weights-container');
         sectionsContainer.innerHTML = '';
@@ -632,13 +1355,14 @@
                             <div class="subsection-item" data-id="${index}">
                                 <div class="d-flex align-items-center mb-2">
                                     <i class="fas fa-grip-vertical drag-handle"></i>
-                                    <input type="text" class="form-control subsection-title-input me-2" 
-                                           value="${sub.title}" 
-                                           data-section="${key}" 
+                                    <input type="text" class="form-control subsection-title-input me-2"
+                                           value="${sub.title}"
+                                           data-section="${key}"
                                            data-index="${index}">
                                     <strong class="flex-grow-1" id="subsection-title-${key}-${index}">${sub.title}</strong>
                                 </div>
                                 <textarea id="editor-${key}-${index}">${sub.content}</textarea>
+                                ${renderModalityCheckboxes(key, sub.modalities, 'subsection', index)}
                                 <div class="subsection-controls">
                                     <button class="btn btn-sm btn-outline-primary duplicate-item" title="Duplicate">
                                         <i class="fas fa-copy"></i>
@@ -658,7 +1382,8 @@
                     <div class="mb-3">
                         <label class="form-label"><i class="fas fa-edit me-2"></i>Section Content</label>
                         <textarea id="editor-${key}">${config.content}</textarea>
-                    </div>`;
+                    </div>
+                    ${renderModalityCheckboxes(key, config.modalities, 'section', 'main')}`;
             }
 
             const sectionHTML = `
@@ -718,6 +1443,7 @@
         setTimeout(() => initEditors(), 100);
         updateWeightSum();
         addEventListeners();
+        updateDeploymentModeUI();
     }
 
     function initEditors(selector = 'textarea') {
@@ -732,19 +1458,20 @@
     }
 
     function addEventListeners() {
-        // Subsection title editing
-        document.addEventListener('input', function(e) {
-            if (e.target.classList.contains('subsection-title-input')) {
-                const section = e.target.dataset.section;
-                const index = e.target.dataset.index;
-                const titleElement = document.getElementById(`subsection-title-${section}-${index}`);
-                if (titleElement) {
-                    titleElement.textContent = e.target.value;
-                }
-                // Update the title in TOOL_CONFIG
-                TOOL_CONFIG[section].subsections[index].title = e.target.value;
-            }
-        });
+        if (!hasDocumentInputListener) {
+            document.addEventListener('input', handleDocumentInput);
+            hasDocumentInputListener = true;
+        }
+
+        if (!hasModalityChangeListener) {
+            document.addEventListener('change', handleModalityCheckboxChange);
+            hasModalityChangeListener = true;
+        }
+
+        const addProfileBtn = document.getElementById('btn-add-profile');
+        if (addProfileBtn) addProfileBtn.onclick = addNewProfile;
+
+        document.querySelectorAll('.profile-action').forEach(btn => btn.onclick = handleProfileAction);
 
         document.querySelectorAll('.add-item').forEach(btn => btn.onclick = e => {
             const section = e.currentTarget.dataset.section;
@@ -756,24 +1483,28 @@
             newItem.innerHTML = `
                 <div class="d-flex align-items-center mb-2">
                     <i class="fas fa-grip-vertical drag-handle"></i>
-                    <input type="text" class="form-control subsection-title-input me-2" 
-                           value="New Standard" 
-                           data-section="${section}" 
+                    <input type="text" class="form-control subsection-title-input me-2"
+                           value="New Standard"
+                           data-section="${section}"
                            data-index="${newIndex}">
                     <strong class="flex-grow-1" id="subsection-title-${section}-${newIndex}">New Standard</strong>
                 </div>
                 <textarea id="editor-${section}-${newIndex}"><strong>New Standard</strong> - Description</textarea>
+                ${renderModalityCheckboxes(section, DEFAULT_MODALITY_KEYS, 'subsection', newIndex)}
                 <div class="subsection-controls">
                     <button class="btn btn-sm btn-outline-primary duplicate-item"><i class="fas fa-copy"></i></button>
                     <button class="btn btn-sm btn-danger remove-item"><i class="fas fa-trash"></i></button>
                 </div>`;
             container.appendChild(newItem);
-            
+
             // Add to TOOL_CONFIG
             TOOL_CONFIG[section].subsections.push({
                 title: "New Standard",
-                content: "<strong>New Standard</strong> - Description"
+                content: "<strong>New Standard</strong> - Description",
+                modalities: [...DEFAULT_MODALITY_KEYS]
             });
+
+            updateDeploymentModeUI(newItem.querySelector('.modality-guidance'));
             
             newItem.querySelector('.remove-item').onclick = () => {
                 const itemIndex = Array.from(container.children).indexOf(newItem);
@@ -793,20 +1524,24 @@
                 dupItem.className = 'subsection-item';
                 dupItem.innerHTML = newItem.innerHTML.replace(new RegExp(newIndex, 'g'), dupIndex);
                 container.appendChild(dupItem);
-                
+
                 // Add to TOOL_CONFIG
                 const itemIndex = Array.from(container.children).indexOf(newItem);
+                const originalSubsection = TOOL_CONFIG[section].subsections[itemIndex];
                 TOOL_CONFIG[section].subsections.splice(itemIndex + 1, 0, {
                     title: title + " (Copy)",
-                    content: content
+                    content: content,
+                    modalities: originalSubsection?.modalities ? [...originalSubsection.modalities] : [...DEFAULT_MODALITY_KEYS]
                 });
-                
+
                 initEditors(`#editor-${section}-${dupIndex}`);
                 setTimeout(() => {
                     tinymce.get(`editor-${section}-${dupIndex}`).setContent(content);
                     dupItem.querySelector('.subsection-title-input').value = title + " (Copy)";
                     document.getElementById(`subsection-title-${section}-${dupIndex}`).textContent = title + " (Copy)";
                 }, 200);
+
+                updateDeploymentModeUI(dupItem.querySelector('.modality-guidance'));
             };
 
             initEditors(`#editor-${section}-${newIndex}`);
@@ -864,6 +1599,8 @@
     }
 
     function saveConfigFile() {
+        DEPLOYMENT_MODALITIES = normalizeDeploymentModalities(DEPLOYMENT_MODALITIES);
+        SCT_PROFILES = Array.isArray(SCT_PROFILES) ? SCT_PROFILES.map(normalizeProfile) : [];
         const finalConfig = {};
         document.querySelectorAll('.section-title-input').forEach(input => {
             const key = input.dataset.key;
@@ -884,13 +1621,28 @@
                         const editor = tinymce.get(item.querySelector('textarea').id);
                         const title = titleInput ? titleInput.value : 'Untitled';
                         const content = editor ? editor.getContent() : '';
-                        return { title, content };
+                        const itemIndex = Array.from(item.parentElement.children).indexOf(item);
+                        const modalityData = TOOL_CONFIG[key]?.subsections?.[itemIndex]?.modalities;
+                        return {
+                            title,
+                            content,
+                            modalities: Array.isArray(modalityData) && modalityData.length ? [...modalityData] : [...DEFAULT_MODALITY_KEYS]
+                        };
                     });
+                finalConfig[key].modalities = Array.isArray(TOOL_CONFIG[key].modalities) && TOOL_CONFIG[key].modalities.length
+                    ? [...TOOL_CONFIG[key].modalities]
+                    : [...DEFAULT_MODALITY_KEYS];
             } else {
                 const editor = tinymce.get(`editor-${key}`);
                 finalConfig[key].content = editor ? editor.getContent() : '';
+                finalConfig[key].modalities = Array.isArray(TOOL_CONFIG[key].modalities) && TOOL_CONFIG[key].modalities.length
+                    ? [...TOOL_CONFIG[key].modalities]
+                    : [...DEFAULT_MODALITY_KEYS];
             }
         });
+
+        finalConfig.deploymentModalities = deepClone(DEPLOYMENT_MODALITIES);
+        finalConfig.sctProfiles = deepClone(SCT_PROFILES);
 
         const blob = new Blob([JSON.stringify(finalConfig, null, 2)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
@@ -901,8 +1653,12 @@
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-        
-        alert('Configuration saved successfully!');
+
+        const feedback = document.getElementById('save-feedback');
+        if (feedback) {
+            feedback.textContent = 'El archivo config.json se ha descargado. Revisa tu carpeta de descargas o impórtalo nuevamente con el botón “Import Config”.';
+            feedback.classList.add('show');
+        }
     }
 
     document.getElementById('btn-save-config').onclick = saveConfigFile;
@@ -910,9 +1666,23 @@
     document.getElementById('btn-preview').onclick = () => {
         const preview = document.getElementById('preview-content');
         preview.innerHTML = '<h3>Configuration Preview</h3>';
-        
+        preview.innerHTML += renderModalitiesPreview();
+        preview.innerHTML += renderProfilesPreview();
+
         Object.entries(TOOL_CONFIG).forEach(([key, config]) => {
             if(!config.enabled) return;
+            const sectionBadges = getModalityBadgeHtml(config.modalities);
+            let bodyContent = '';
+            if (config.hasSubsections) {
+                const items = config.subsections.map(sub => {
+                    const subBadges = getModalityBadgeHtml(sub.modalities);
+                    return `<li class="mb-2"><div class="fw-semibold">${sub.title}</div>${subBadges}</li>`;
+                }).join('');
+                bodyContent = `<ul class="mb-0">${items}</ul>`;
+            } else {
+                bodyContent = `<div class="preview-content">${config.content || 'Custom content section'}</div>`;
+            }
+
             preview.innerHTML += `
                 <div class="card mb-3">
                     <div class="card-header">
@@ -920,14 +1690,12 @@
                         <small class="text-muted">Weight: ${config.weight}%</small>
                     </div>
                     <div class="card-body">
-                        ${config.hasSubsections ? 
-                            '<ul>' + config.subsections.map(s => `<li>${s.title}</li>`).join('') + '</ul>' :
-                            '<div class="preview-content">' + (config.content || 'Custom content section') + '</div>'
-                        }
+                        ${sectionBadges}
+                        ${bodyContent}
                     </div>
                 </div>`;
         });
-        
+
         document.getElementById('preview-mode').style.display = 'block';
     };
 
@@ -946,7 +1714,13 @@
         const reader = new FileReader();
         reader.onload = (evt) => {
             try {
-                TOOL_CONFIG = JSON.parse(evt.target.result);
+                const importedConfig = JSON.parse(evt.target.result);
+                const { deploymentModalities, sctProfiles, ...sections } = importedConfig;
+                if (deploymentModalities) {
+                    DEPLOYMENT_MODALITIES = normalizeDeploymentModalities(deploymentModalities);
+                }
+                SCT_PROFILES = Array.isArray(sctProfiles) ? sctProfiles.map(normalizeProfile) : [];
+                TOOL_CONFIG = sections;
                 renderMakerUI();
                 alert('Configuration imported successfully!');
             } catch(err) {

--- a/template.html
+++ b/template.html
@@ -185,6 +185,24 @@
                 </div>
                 <div class="col-lg-8">
                     <div class="main-content">
+                        <div class="d-flex align-items-center justify-content-end mb-3 gap-3 flex-wrap" id="modality-filter-container" style="display:none;">
+                            <div class="d-flex align-items-center gap-2" id="profile-filter-wrapper" style="display:none;">
+                                <label for="profile-filter" class="text-muted small fw-semibold mb-0">Perfil SCT</label>
+                                <select class="form-select form-select-sm w-auto" id="profile-filter">
+                                    <option value="all">Todos los perfiles</option>
+                                </select>
+                            </div>
+                            <div class="d-flex align-items-center gap-2" id="modality-filter-wrapper" style="display:none;">
+                                <label for="modality-filter" class="text-muted small fw-semibold mb-0">Filtrar por modalidad de despliegue</label>
+                                <select class="form-select form-select-sm w-auto" id="modality-filter">
+                                    <option value="all">Todas las modalidades</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="alert alert-info d-none" id="profile-summary-panel"></div>
+                        <div class="alert alert-warning d-none" id="modality-filter-empty">
+                            <i class="fas fa-filter me-2"></i>No hay estándares visibles para la modalidad seleccionada. Ajusta el filtro para revisar otros requisitos.
+                        </div>
                         <div class="tab-content" id="tab-content-container"></div>
                         <div class="d-flex justify-content-between mt-4 flex-wrap gap-2">
                             <div>
@@ -244,9 +262,13 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
     let CONFIG = {};
+    let DEPLOYMENT_MODALITIES = null;
     let SECTIONS_WITH_WEIGHT = [];
     let progressChart = null;
     let logoDataUrl = '';
+    let currentModalityFilter = 'all';
+    let currentProfileFilter = 'all';
+    let SCT_PROFILES = [];
     let assessmentData = {
         teamInfo: {},
         scores: {},
@@ -257,17 +279,379 @@
         summary: {}
     };
 
+    const escapeHtml = (unsafe = '') => unsafe
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+
+    const formatMultiline = (text = '') => escapeHtml(text).replace(/\n/g, '<br>');
+
+    const PROFILE_FIELD_GROUPS = [
+        { key: 'operationalSupport', label: 'Operational Support & Logistics' },
+        { key: 'staffing', label: 'Staffing & Integration' },
+        { key: 'spacesInfrastructure', label: 'Spaces & Structures' },
+        { key: 'suppliesEquipment', label: 'Supplies & Equipment' },
+        { key: 'coordinationCommunication', label: 'Coordination & Communication' },
+        { key: 'safetySecurity', label: 'Safety & Security' },
+        { key: 'clinicalServices', label: 'Medical Services & Capabilities' },
+        { key: 'washIpc', label: 'WASH / IPC' },
+        { key: 'integrationNotes', label: 'Host Facility Agreements & Notes' }
+    ];
+
+    const normalizeProfile = (profile = {}) => {
+        const readiness = {};
+        PROFILE_FIELD_GROUPS.forEach(group => {
+            readiness[group.key] = profile?.readiness?.[group.key] || '';
+        });
+
+        return {
+            id: profile.id || `profile-${Math.random().toString(16).slice(2, 8)}`,
+            name: profile.name || '',
+            summary: profile.summary || '',
+            modalities: Array.isArray(profile.modalities) ? profile.modalities.filter(Boolean) : [],
+            readiness,
+            sctDeliverables: profile.sctDeliverables || '',
+            hostExpectations: profile.hostExpectations || '',
+            coordinationNotes: profile.coordinationNotes || ''
+        };
+    };
+
+    const MODALITY_META = {
+        'embedded': { icon: 'fa-hospital-user', badgeClass: 'bg-primary text-white' },
+        'coupled': { icon: 'fa-link', badgeClass: 'bg-warning text-dark' },
+        'self-sustained': { icon: 'fa-campground', badgeClass: 'bg-success text-white' }
+    };
+
+    function getModalityBadgeHtml(modalities = []) {
+        if (!Array.isArray(modalities) || modalities.length === 0) return '';
+        return `<div class="d-flex flex-wrap gap-2 mt-2">${modalities.map(modality => {
+            const meta = MODALITY_META[modality] || {};
+            const label = DEPLOYMENT_MODALITIES?.[modality]?.label || modality;
+            return `<span class="badge ${meta.badgeClass || 'bg-secondary'}"><i class="fas ${meta.icon || 'fa-circle'} me-1"></i>${escapeHtml(label)}</span>`;
+        }).join('')}</div>`;
+    }
+
+    function buildModalitiesTab() {
+        if (!DEPLOYMENT_MODALITIES) return '';
+
+        const cardGrid = Object.entries(DEPLOYMENT_MODALITIES).map(([key, data]) => {
+            const meta = MODALITY_META[key] || {};
+            return `
+                <div class="col-lg-4">
+                    <div class="card h-100 border-0 shadow-sm">
+                        <div class="card-body">
+                            <h5 class="card-title"><i class="fas ${meta.icon || 'fa-circle'} me-2"></i>${escapeHtml(data.label || key)}</h5>
+                            <p class="card-text text-muted">${formatMultiline(data.description || '')}</p>
+                            <div class="mb-3">
+                                <h6 class="text-uppercase small text-muted">Operational & Logistics</h6>
+                                <p class="small mb-0">${formatMultiline(data.operationalSupport || '')}</p>
+                            </div>
+                            <div class="mb-3">
+                                <h6 class="text-uppercase small text-muted">WASH / IPC</h6>
+                                <p class="small mb-0">${formatMultiline(data.washConsiderations || '')}</p>
+                            </div>
+                            <div class="mb-3">
+                                <h6 class="text-uppercase small text-muted">Clinical Focus</h6>
+                                <p class="small mb-0">${formatMultiline(data.clinicalConsiderations || '')}</p>
+                            </div>
+                            <div class="mb-3">
+                                <h6 class="text-uppercase small text-muted">Paquete aportado por el SCT</h6>
+                                <p class="small mb-0">${formatMultiline(data.teamResponsibilities || '')}</p>
+                            </div>
+                            <div>
+                                <h6 class="text-uppercase small text-muted">Apoyo requerido del establecimiento anfitrión</h6>
+                                <p class="small mb-0">${formatMultiline(data.hostFacilitySupport || '')}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>`;
+        }).join('');
+
+        const sectionRows = Object.entries(CONFIG)
+            .filter(([, section]) => section.enabled)
+            .map(([key, section]) => {
+                const sectionBadges = getModalityBadgeHtml(section.modalities);
+                let detailHtml = '';
+                if (section.hasSubsections && Array.isArray(section.subsections)) {
+                    detailHtml = section.subsections.map(sub => {
+                        const modalities = Array.isArray(sub.modalities) && sub.modalities.length
+                            ? sub.modalities
+                            : (Array.isArray(section.modalities) && section.modalities.length
+                                ? section.modalities
+                                : (DEPLOYMENT_MODALITIES ? Object.keys(DEPLOYMENT_MODALITIES) : []));
+                        const subBadges = getModalityBadgeHtml(modalities);
+                        return `<div class="mb-2"><strong>${sub.title}</strong>${subBadges}</div>`;
+                    }).join('');
+                } else {
+                    detailHtml = '<div class="text-muted small">Applies to entire section content.</div>';
+                }
+
+                return `
+                    <tr>
+                        <td><strong><i class="fas ${section.icon} me-2"></i>${section.title}</strong></td>
+                        <td>${sectionBadges || '<span class="text-muted">Not specified</span>'}</td>
+                        <td>${detailHtml || '<span class="text-muted">No detailed items configured.</span>'}</td>
+                    </tr>`;
+            }).join('');
+
+        return `
+            <div class="tab-pane fade" id="deployment-modalities">
+                <div class="section-card">
+                    <div class="section-header d-flex justify-content-between align-items-center">
+                        <h5>Deployment Modalities Overview</h5>
+                        <div class="score-display">Responsibility Mapping</div>
+                    </div>
+                    <div class="assessment-container">
+                        <div class="row g-4">${cardGrid}</div>
+                    </div>
+                </div>
+                <div class="section-card mt-4">
+                    <div class="section-header d-flex justify-content-between align-items-center">
+                        <h5>Modalities applied to sections</h5>
+                        <div class="score-display">Checklist linkage</div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover align-middle">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Section</th>
+                                    <th>Applicable Modalities</th>
+                                    <th>Details</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                ${sectionRows || '<tr><td colspan="3" class="text-center text-muted">No sections configured.</td></tr>'}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>`;
+    }
+
+    function buildProfilesTab() {
+        if (!Array.isArray(SCT_PROFILES) || SCT_PROFILES.length === 0) return '';
+
+        const cards = SCT_PROFILES.map(profile => {
+            const badges = getModalityBadgeHtml(profile.modalities);
+            const readiness = PROFILE_FIELD_GROUPS
+                .filter(group => (profile.readiness?.[group.key] || '').trim().length)
+                .map(group => `<div class="col-md-6"><div class="border-start ps-3"><h6 class="small text-uppercase text-muted mb-1">${group.label}</h6><p class="small mb-0">${formatMultiline(profile.readiness?.[group.key] || '')}</p></div></div>`)
+                .join('');
+
+        return `
+            <div class="section-card">
+                <div class="section-header d-flex justify-content-between align-items-center">
+                    <h5>${escapeHtml(profile.name || 'Perfil sin título')}</h5>
+                    <div class="score-display">${badges || '<span class="badge bg-secondary">Modalidades no definidas</span>'}</div>
+                </div>
+                <div class="assessment-container">
+                    ${profile.summary ? `<p class="text-muted">${formatMultiline(profile.summary)}</p>` : '<p class="text-muted">Sin descripción</p>'}
+                    ${readiness ? `<div class="row g-3">${readiness}</div>` : '<div class="alert alert-light border">Utiliza los campos del configurador para detallar las prioridades del checklist.</div>'}
+                    <div class="row g-3 mt-2">
+                        <div class="col-md-6">
+                            <div class="p-3 bg-light rounded h-100">
+                                <h6 class="text-uppercase small text-muted">SCT delivers</h6>
+                                <p class="mb-0">${formatMultiline(profile.sctDeliverables || 'Sin definir')}</p>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="p-3 bg-light rounded h-100">
+                                <h6 class="text-uppercase small text-muted">Host facility ensures</h6>
+                                <p class="mb-0">${formatMultiline(profile.hostExpectations || 'Sin definir')}</p>
+                            </div>
+                        </div>
+                    </div>
+                    ${profile.coordinationNotes ? `<div class="mt-3"><strong>Coordinación & contingencias:</strong> ${formatMultiline(profile.coordinationNotes)}</div>` : ''}
+                </div>
+            </div>`;
+        }).join('');
+
+        return `<div class="tab-pane fade" id="sct-profiles">${cards}</div>`;
+    }
+
+    function getActiveModalitiesForFiltering() {
+        let active = [];
+        if (currentModalityFilter !== 'all') {
+            active = [currentModalityFilter];
+        }
+
+        const profile = currentProfileFilter !== 'all'
+            ? SCT_PROFILES.find(item => item.id === currentProfileFilter)
+            : null;
+
+        if (profile && Array.isArray(profile.modalities) && profile.modalities.length) {
+            if (active.length) {
+                active = active.filter(mode => profile.modalities.includes(mode));
+            } else {
+                active = [...profile.modalities];
+            }
+        }
+
+        return active.filter((value, index, self) => self.indexOf(value) === index);
+    }
+
+    function applyModalityFilter() {
+        const filterSelect = document.getElementById('modality-filter');
+        const emptyAlert = document.getElementById('modality-filter-empty');
+        if (!filterSelect) return;
+
+        const activeModalities = getActiveModalitiesForFiltering();
+        const items = document.querySelectorAll('.standard-item');
+
+        items.forEach(item => {
+            const modalities = (item.dataset.modalities || '').split(',').filter(Boolean);
+            const matches = !activeModalities.length || modalities.length === 0 || activeModalities.some(mode => modalities.includes(mode));
+            item.style.display = matches ? '' : 'none';
+        });
+
+        document.querySelectorAll('.tab-pane .section-card').forEach(card => {
+            if (card.closest('#deployment-modalities')) return;
+            const standards = card.querySelectorAll('.standard-item');
+            if (!standards.length) return;
+            const hasVisible = Array.from(standards).some(item => item.style.display !== 'none');
+            card.style.display = hasVisible ? '' : 'none';
+        });
+
+        if (emptyAlert) {
+            const activePane = document.querySelector('.tab-pane.active');
+            if (!activePane || activePane.id === 'deployment-modalities' || !activeModalities.length) {
+                emptyAlert.classList.add('d-none');
+            } else {
+                const hasVisibleInActive = Array.from(activePane.querySelectorAll('.standard-item')).some(item => item.style.display !== 'none');
+                emptyAlert.classList.toggle('d-none', hasVisibleInActive);
+            }
+        }
+
+        updateProfileSummary();
+    }
+
+    function updateProfileSummary() {
+        const panel = document.getElementById('profile-summary-panel');
+        if (!panel) return;
+
+        if (currentProfileFilter === 'all') {
+            panel.classList.add('d-none');
+            panel.innerHTML = '';
+            return;
+        }
+
+        const profile = SCT_PROFILES.find(item => item.id === currentProfileFilter);
+        if (!profile) {
+            panel.classList.add('d-none');
+            panel.innerHTML = '';
+            return;
+        }
+
+        const badges = getModalityBadgeHtml(profile.modalities);
+        const readiness = PROFILE_FIELD_GROUPS
+            .filter(group => (profile.readiness?.[group.key] || '').trim().length)
+            .map(group => `<div class="col-md-6"><div class="border-start ps-3"><h6 class="small text-uppercase text-muted mb-1">${group.label}</h6><p class="small mb-0">${formatMultiline(profile.readiness?.[group.key] || '')}</p></div></div>`)
+            .join('');
+
+        panel.innerHTML = `
+            <div class="d-flex flex-column gap-2">
+                <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
+                    <div>
+                        <h5 class="mb-1">${escapeHtml(profile.name || 'Perfil sin título')}</h5>
+                        ${profile.summary ? `<p class="mb-0 text-muted">${formatMultiline(profile.summary)}</p>` : '<p class="mb-0 text-muted">Sin descripción</p>'}
+                    </div>
+                    ${badges}
+                </div>
+                ${readiness ? `<div class="row g-3">${readiness}</div>` : ''}
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <strong>SCT:</strong> ${formatMultiline(profile.sctDeliverables || 'Sin definir')}
+                    </div>
+                    <div class="col-md-6">
+                        <strong>Anfitrión:</strong> ${formatMultiline(profile.hostExpectations || 'Sin definir')}
+                    </div>
+                </div>
+                ${profile.coordinationNotes ? `<div><strong>Coordinación:</strong> ${formatMultiline(profile.coordinationNotes)}</div>` : ''}
+            </div>`;
+        panel.classList.remove('d-none');
+    }
+
     // Initialize the application with the provided configuration
     function initializeApp(config) {
-        CONFIG = config;
+        const { deploymentModalities, sctProfiles, ...sectionConfig } = config;
+        DEPLOYMENT_MODALITIES = deploymentModalities || null;
+        SCT_PROFILES = Array.isArray(sctProfiles) ? sctProfiles.map(normalizeProfile) : [];
+        CONFIG = sectionConfig;
         SECTIONS_WITH_WEIGHT = Object.entries(CONFIG)
             .filter(([, c]) => c.weight > 0)
             .map(([k, c]) => ({ name: c.title, weight: c.weight, section: k }));
 
+        currentModalityFilter = 'all';
+        currentProfileFilter = 'all';
+
         const sidebarNav = document.getElementById('sidebar-nav-container');
         const tabContent = document.getElementById('tab-content-container');
+        const filterContainer = document.getElementById('modality-filter-container');
+        const filterSelect = document.getElementById('modality-filter');
+        const profileWrapper = document.getElementById('profile-filter-wrapper');
+        const profileSelect = document.getElementById('profile-filter');
+        const modalityWrapper = document.getElementById('modality-filter-wrapper');
         let sidebarLinks = '';
         let tabPanes = '';
+
+        const showModalitiesFilter = !!DEPLOYMENT_MODALITIES;
+        const showProfilesFilter = SCT_PROFILES.length > 0;
+
+        if (filterContainer) {
+            filterContainer.style.display = (showModalitiesFilter || showProfilesFilter) ? 'flex' : 'none';
+        }
+        if (profileWrapper) profileWrapper.style.display = showProfilesFilter ? 'flex' : 'none';
+        if (modalityWrapper) modalityWrapper.style.display = showModalitiesFilter ? 'flex' : 'none';
+
+        if (showModalitiesFilter && filterSelect) {
+            const options = Object.entries(DEPLOYMENT_MODALITIES).map(([key, data]) => `<option value="${key}">${escapeHtml(data.label || key)}</option>`).join('');
+            filterSelect.innerHTML = `<option value="all">Todas las modalidades</option>${options}`;
+            filterSelect.value = currentModalityFilter;
+            filterSelect.onchange = (event) => {
+                currentModalityFilter = event.target.value;
+                applyModalityFilter();
+            };
+        } else if (filterSelect) {
+            filterSelect.innerHTML = '<option value="all">Todas las modalidades</option>';
+            filterSelect.onchange = null;
+        }
+
+        if (showProfilesFilter && profileSelect) {
+            const options = SCT_PROFILES.map(profile => `<option value="${profile.id}">${escapeHtml(profile.name || 'Perfil sin título')}</option>`).join('');
+            profileSelect.innerHTML = `<option value="all">Todos los perfiles</option>${options}`;
+            profileSelect.value = currentProfileFilter;
+            profileSelect.onchange = (event) => {
+                currentProfileFilter = event.target.value;
+                if (currentProfileFilter !== 'all' && currentModalityFilter !== 'all') {
+                    const selectedProfile = SCT_PROFILES.find(item => item.id === currentProfileFilter);
+                    if (!selectedProfile || !selectedProfile.modalities.includes(currentModalityFilter)) {
+                        currentModalityFilter = 'all';
+                        if (filterSelect) filterSelect.value = 'all';
+                    }
+                }
+                applyModalityFilter();
+            };
+        } else if (profileSelect) {
+            profileSelect.innerHTML = '<option value="all">Todos los perfiles</option>';
+            profileSelect.onchange = null;
+        }
+
+        if (!showModalitiesFilter) {
+            const emptyAlert = document.getElementById('modality-filter-empty');
+            if (emptyAlert) emptyAlert.classList.add('d-none');
+        }
+
+        if (SCT_PROFILES.length) {
+            sidebarLinks += `<li class="nav-item"><a class="nav-link" href="#sct-profiles" data-bs-toggle="tab"><i class="fas fa-people-group"></i> SCT Profiles</a></li>`;
+            tabPanes += buildProfilesTab();
+        }
+
+        if (DEPLOYMENT_MODALITIES) {
+            sidebarLinks += `<li class="nav-item"><a class="nav-link" href="#deployment-modalities" data-bs-toggle="tab"><i class="fas fa-sitemap"></i> Modalities</a></li>`;
+            tabPanes += buildModalitiesTab();
+        }
 
         Object.entries(CONFIG).forEach(([key, configData]) => {
             if (!configData.enabled) return;
@@ -279,7 +663,7 @@
                 const standardItems = configData.subsections.map((sub, index) => {
                     // Handle both string and object formats for subsections
                     let title, description, fullContent;
-                    
+
                     if (typeof sub === 'string') {
                         // String format (like config(5).json)
                         const cleanSub = sub.replace(/<strong>(.*?)<\/strong>/g, '$1');
@@ -297,11 +681,18 @@
                         description = '';
                         fullContent = '';
                     }
-                    
-                    const subId = title.replace(/<[^>]*>?/gm, '').toLowerCase().replace(/[^\w\s]/gi, '').replace(/\s+/g, '-').slice(0, 50);
 
-                    return `<div class="standard-item">
+                    const subId = title.replace(/<[^>]*>?/gm, '').toLowerCase().replace(/[^\w\s]/gi, '').replace(/\s+/g, '-').slice(0, 50);
+                    const subModalities = Array.isArray(sub.modalities) && sub.modalities.length
+                        ? sub.modalities
+                        : (Array.isArray(configData.modalities) && configData.modalities.length
+                            ? configData.modalities
+                            : (DEPLOYMENT_MODALITIES ? Object.keys(DEPLOYMENT_MODALITIES) : []));
+                    const subBadges = getModalityBadgeHtml(subModalities);
+
+                    return `<div class="standard-item" data-modalities="${Array.isArray(subModalities) ? subModalities.join(',') : ''}">
                         <div class="standard-header">${title}</div>
+                        ${subBadges}
                         ${description ? `<div class="standard-description">${description}</div>` : ''}
                         <div class="score-evidence-grid">
                             <div class="score-section">
@@ -347,7 +738,9 @@
                 </div>`;
             } else {
                 // Use content from config or default template
-                content = configData.content || `<div class="alert alert-info">Content for ${configData.title}</div>`;
+                const baseContent = configData.content || `<div class="alert alert-info">Content for ${configData.title}</div>`;
+                const sectionBadges = getModalityBadgeHtml(configData.modalities);
+                content = `${sectionBadges ? `<div class="alert alert-light border mb-3">${sectionBadges}</div>` : ''}${baseContent}`;
             }
 
             tabPanes += `<div class="tab-pane fade" id="${key}">${content}</div>`;
@@ -360,6 +753,8 @@
         if (firstNavLink) firstNavLink.classList.add('active');
         const firstTabPane = tabContent.querySelector('.tab-pane');
         if (firstTabPane) firstTabPane.classList.add('show', 'active');
+
+        applyModalityFilter();
 
         document.getElementById('config-loader-overlay').style.display = 'none';
         document.getElementById('app-wrapper').style.display = 'block';
@@ -1035,17 +1430,23 @@
             if (e.target.files.length > 0) {
                 const file = e.target.files[0];
                 const reader = new FileReader();
-                
+
                 reader.onload = function(event) {
                     logoDataUrl = event.target.result;
-                    document.getElementById('logo-preview-container').innerHTML = 
+                    document.getElementById('logo-preview-container').innerHTML =
                         `<img src="${logoDataUrl}" class="logo-preview" alt="Logo Preview">`;
                 };
-                
+
                 reader.readAsDataURL(file);
             }
         });
-        
+
+        document.querySelectorAll('a[data-bs-toggle="tab"]').forEach(link => {
+            link.addEventListener('shown.bs.tab', () => {
+                applyModalityFilter();
+            });
+        });
+
         // Score select change events
         document.addEventListener('change', (e) => {
             if (e.target.classList.contains('score-select')) {


### PR DESCRIPTION
## Summary
- add SCT deployment profile cards to the configuration maker with readiness field groups, host/SCT responsibilities, and persistence in exports/imports
- extend the maker preview and assessment template with an SCT profiles tab plus profile-aware modality filtering and summary guidance
- document how to capture SCT deployment profiles and review them inside the template UI

## Testing
- not run (static HTML/JS changes)

------
https://chatgpt.com/codex/tasks/task_e_68dcf4cc89d4832a8675aaab51b2c52c